### PR TITLE
[FEAT] Ticket이 존재하지 않을 때, 티켓이 존재하지 않는다는 화면을 표시

### DIFF
--- a/AsyncSwift/Assets.xcassets/Colors/emptyTicketViewBackground.colorset/Contents.json
+++ b/AsyncSwift/Assets.xcassets/Colors/emptyTicketViewBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xFB",
+          "red" : "0xFB"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AsyncSwift/Assets.xcassets/Colors/emptyTicketViewForeground.colorset/Contents.json
+++ b/AsyncSwift/Assets.xcassets/Colors/emptyTicketViewForeground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD8",
+          "green" : "0xD8",
+          "red" : "0xD8"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/AsyncSwift/Extensions/Color+.swift
+++ b/AsyncSwift/Extensions/Color+.swift
@@ -11,6 +11,8 @@ import SwiftUI
 extension Color {
     static let seminarOrange = Color("seminarOrange")
     static let dividerForeground = Color("dividerForeground")
+    static let emptyTicketViewBackground = Color("emptyTicketViewBackground")
+    static let emptyTicketViewForeground = Color("emptyTicketViewForeground")
     static let speakerBackground = Color("speakerBackground")
     static let skeletonBackground = Color("skeletonBackground")
 }

--- a/AsyncSwift/Models/Ticketing.swift
+++ b/AsyncSwift/Models/Ticketing.swift
@@ -14,6 +14,7 @@ struct Ticketing: Decodable {
     struct CurrentTicket: Decodable {
         let ticketingImageURL: String
         let ticketingURL: String
+        let date: String
     }
 
     struct UpcomingEvent: Decodable {

--- a/AsyncSwift/Observed/TicketingView+Observed.swift
+++ b/AsyncSwift/Observed/TicketingView+Observed.swift
@@ -19,7 +19,9 @@ extension TicketingView {
             return currentDate <= DateFormatter.calendarFormatter.date(from: ticketing?.currentTicket?.date ?? "") ?? Date()
         }
 
-        var isTicketingLinkDisabled: Bool { ticketing?.currentTicket?.ticketingURL == nil }
+        var isTicketingLinkDisabled: Bool {
+            ticketing?.currentTicket?.ticketingURL == nil && !hasAvailableTicket
+        }
 
         func onAppear() {
             guard

--- a/AsyncSwift/Observed/TicketingView+Observed.swift
+++ b/AsyncSwift/Observed/TicketingView+Observed.swift
@@ -14,7 +14,11 @@ extension TicketingView {
 
         @Published var isActivatedWebViewNavigationLink = false
 
-        var hasAvailableTicket: Bool { ticketing?.currentTicket?.ticketingImageURL != nil }
+        var hasAvailableTicket: Bool {
+            let currentDate = Date()
+            return currentDate <= DateFormatter.calendarFormatter.date(from: ticketing?.currentTicket?.date ?? "") ?? Date()
+        }
+
         var isTicketingLinkDisabled: Bool { ticketing?.currentTicket?.ticketingURL == nil }
 
         func onAppear() {

--- a/AsyncSwift/Observed/TicketingView+Observed.swift
+++ b/AsyncSwift/Observed/TicketingView+Observed.swift
@@ -14,7 +14,7 @@ extension TicketingView {
 
         @Published var isActivatedWebViewNavigationLink = false
 
-        var doesCurrentTicketExist: Bool { ticketing?.currentTicket?.ticketingImageURL != nil }
+        var hasAvailableTicket: Bool { ticketing?.currentTicket?.ticketingImageURL != nil }
         var isTicketingLinkDisabled: Bool { ticketing?.currentTicket?.ticketingURL == nil }
 
         func onAppear() {

--- a/AsyncSwift/Observed/TicketingView+Observed.swift
+++ b/AsyncSwift/Observed/TicketingView+Observed.swift
@@ -14,7 +14,7 @@ extension TicketingView {
 
         @Published var isActivatedWebViewNavigationLink = false
 
-        var isNeedToShowTicketingView: Bool { ticketing?.currentTicket?.ticketingImageURL != nil }
+        var doesCurrentTicketExist: Bool { ticketing?.currentTicket?.ticketingImageURL != nil }
         var isTicketingLinkDisabled: Bool { ticketing?.currentTicket?.ticketingURL == nil }
 
         func onAppear() {

--- a/AsyncSwift/Views/TicketingView.swift
+++ b/AsyncSwift/Views/TicketingView.swift
@@ -23,7 +23,7 @@ struct TicketingView: View {
                             .ticketingViewStyle()
                     }
 
-                    switch observed.doesCurrentTicketExist {
+                    switch observed.hasAvailableTicket {
                     case true:
                         ticketingView
                             .ticketingViewStyle()

--- a/AsyncSwift/Views/TicketingView.swift
+++ b/AsyncSwift/Views/TicketingView.swift
@@ -10,23 +10,26 @@ import SwiftUI
 struct TicketingView: View {
     @StateObject private var observed = Observed()
 
-    private let shadowColor = Color(.sRGB, red: 0, green: 0, blue: 0, opacity: 0.15)
-    private let corenrRadius: CGFloat = 8.0
-
 	var body: some View {
 		NavigationView {
 			ScrollView {
 				VStack(spacing: 30) {
-                    if observed.isNeedToShowTicketingView {
-                        ticketingView
-                    }
-
                     if let upcomingEvent = observed.ticketing?.upcomingEvent {
                         makeUpcomingEventView(from: upcomingEvent)
+                            .ticketingViewStyle()
                     } else {
                         skeletonView
                             .aspectRatio(2.75, contentMode: .fill)
-                            .cornerRadius(corenrRadius)
+                            .ticketingViewStyle()
+                    }
+
+                    switch observed.doesCurrentTicketExist {
+                    case true:
+                        ticketingView
+                            .ticketingViewStyle()
+                    case false:
+                        emptyTicketingView
+                            .ticketingViewStyle()
                     }
                 }
                 .padding(30)
@@ -36,6 +39,25 @@ struct TicketingView: View {
         }.onAppear {
             observed.onAppear()
         }
+    }
+}
+
+fileprivate extension TicketingView {
+    struct TicketingViewStyle: ViewModifier {
+        func body(content: Content) -> some View {
+            content
+                .cornerRadius(8.0)
+                .shadow(
+                    color: Color(.sRGB, red: 0, green: 0, blue: 0, opacity: 0.15),
+                    radius: 20, x: 0, y: 4
+                )
+        }
+    }
+}
+
+fileprivate extension View {
+    func ticketingViewStyle() -> some View {
+        modifier(TicketingView.TicketingViewStyle())
     }
 }
 
@@ -70,9 +92,17 @@ private extension TicketingView {
                         .aspectRatio(0.85, contentMode: .fill)
                 }
             )
-            .cornerRadius(corenrRadius)
-            .shadow(color: shadowColor, radius: 20, x: 0, y: 4)
         }.disabled(observed.isTicketingLinkDisabled)
+    }
+
+    var emptyTicketingView: some View {
+        Text("현재 판매중인 티켓이 없습니다.")
+            .fontWeight(.bold)
+            .font(.body)
+            .foregroundColor(.emptyTicketViewForeground)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .aspectRatio(0.85, contentMode: .fill)
+            .background(Color.emptyTicketViewBackground)
     }
 
     @ViewBuilder
@@ -105,8 +135,6 @@ private extension TicketingView {
                 endPoint: .trailing
             )
         )
-        .cornerRadius(corenrRadius)
-        .shadow(color: shadowColor, radius: 20, x: 0, y: 4)
     }
 }
 


### PR DESCRIPTION
# Overview

- 오픈된 티켓/이벤트가 없을 때 티켓팅 가능한 이벤트가 없다는 것을 표시하기 위한 화면을 구현하였습니다.

## 완성된 화면
존재할 때|존재하지 않을 때
---|---
![image](https://user-images.githubusercontent.com/28520053/190377576-73b69a86-a39f-4e4b-a7a3-c8df7b966ebe.png)|![Simulator Screen Shot - iPhone 13 - 2022-09-15 at 19 08 52](https://user-images.githubusercontent.com/28520053/190377403-0b11f2dd-1379-4f5b-b4ba-827fa557490b.png)
