### PR TITLE
[FIX] TicketingView Image Loading 사실을 알기쉽도록 스켈레톤의 색 대비를 높임.

### DIFF
--- a/AsyncSwift/Assets.xcassets/Colors/skeletonBackground.colorset/Contents.json
+++ b/AsyncSwift/Assets.xcassets/Colors/skeletonBackground.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.920",
-          "blue" : "0xEA",
-          "green" : "0xE5",
-          "red" : "0xE5"
+          "alpha" : "1.000",
+          "blue" : "0xD6",
+          "green" : "0xD1",
+          "red" : "0xD1"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
# Overview
<!-- 어떤 작업에 대한 PR인지 알려주세요. -->

## 발생 중인 이슈의 재현방법

1. 앱을 기동 
2. Ticketing 탭 클릭 후 바로(1초 안에) 다른 탭으로 이동 
3. AsyncImage를 사용한 TicketingView가 스켈레톤에서 멈춰버림.

## 이슈의 발생 이유

AsyncImage가 화면에서 보여지는 상태가 아니면, Image request를 cancelled해버림.
이 이후로 다시 화면에 AsyncImage가 보여지더라도 reload를 하지않음.

## 해결방법

<img width="624" alt="스크린샷 2022-09-19 오전 3 29 54" src="https://user-images.githubusercontent.com/28520053/190922812-bf7181ec-b2b4-4f4f-8966-b647109e2eb8.png">

### 1. 스켈레톤의 색대비 높임 (왼쪽) ✅ 

- TicketingView Image Loading 사실을 알기쉽도록 스켈레톤의 색 대비를 높임.
- 사실 1..초 정도만 기다리면.... 이 버그는 발생하지 않..는다 ..

### 2. Reload 버튼 삽입 후 유저가 수동으로 리로드

- 화면의 디자인은 @unnnyong 이 가안으로 만든 디자인.
- 디자인확인 등의 추가시간이 소요될 것으로 보임.

# Next TODO
<!-- Optional -->

- AsyncsImage에서 Image 취득에 실패했을 때 reload 타이밍과 트리거 셋팅.

# Reference
<!-- 작업에서 참고한 디자인 파일 링크 등의 레퍼런스를 알려주세요. -->
- https://www.figma.com/file/6u38eFhfGAfpXPVIv1Bgdh/AsyncSwift?node-id=1004%3A9687

---

**여담.**

AsyncImage가 cancelled된다면, Tab에서 AsyncImage를 사용할 장점보다 단점이 너무 커지는거아닌가 .. !