### PR TITLE
[Fix] 친구 삭제 Alert 문구 및 HIG에 맞게 수정

### DIFF
--- a/AsyncSwift/Views/Profile/ProfileFriendDetailView.swift
+++ b/AsyncSwift/Views/Profile/ProfileFriendDetailView.swift
@@ -46,12 +46,18 @@ struct ProfileFriendDetailView: View {
                     .ignoresSafeArea()
             }
         })
-        .alert("삭제", isPresented: $observed.isShowingConfirmAlert, actions: {
-            Button("삭제") { observed.isShowingConfirmAlert = false }
-            Button("확인") { observed.didConfirmDelete() }
-        }, message: {
-            Text("유저를 친구 목록에서 삭제하시겠습니까?")
-        })
+        .alert(isPresented: $observed.isShowingConfirmAlert) {
+            Alert(
+                title: Text("삭제"),
+                message: Text("유저 친구 목록에서 삭제하시겠습니까?"),
+                primaryButton: .destructive(Text("삭제")) {
+                    observed.didConfirmDelete()
+                },
+                secondaryButton: .cancel(Text("취소")) {
+                    observed.isShowingConfirmAlert = false
+                }
+            )
+        }
     }
 }
 


### PR DESCRIPTION
# Overview
친구 삭제시에 나오는 Alert 문구 수정 및 삭제 버튼을 빨간색으로 처리하여 HIG에 맞게 수정하였습니다.

# Reference
<!-- 작업에서 참고한 디자인 파일 링크 등의 레퍼런스를 알려주세요. -->
|Before|After|
|-|-|
|<img src="https://user-images.githubusercontent.com/55151796/200867886-edbfc9a6-8ff8-4b8c-9870-2f3d53893dc3.jpeg" height=300>|<img src="https://user-images.githubusercontent.com/55151796/200868260-709699d5-b453-47bc-b07f-4ccab9a73cee.jpeg" height=300>|
